### PR TITLE
Add libsavgba 3.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Project               | Version            | Dependencies               | Progra
 [grit]                | 0.9.2              |                            | `grit`
 [libfat] [^1]         | 1.1.5.r2.g69543f0  | `libfat`                   |
 [libgba]              | r136.0d46fc9       | `libgba`                   |
+[libsavgba]           | 3.3.2              | `libtonc`                  |
 [libseven]            | 0.22.3             | `libseven`                 |
 [libtonc]             | r15.cc862ce        | `libtonc`                  |
 [libugba/libsysgba]   | 0.3.0              | `libugba`, `libsysgba`     |
@@ -129,6 +130,7 @@ See the homepages of the bundled projects for their respective licensing.
 [grit]: https://github.com/devkitPro/grit
 [libfat]: https://github.com/devkitPro/libfat
 [libgba]: https://github.com/gbadev-org/libgba
+[libsavgba]: https://github.com/aronson/libsavgba
 [libseven]: https://github.com/sdk-seven/libseven
 [libtonc]: https://github.com/gbadev-org/libtonc
 [libugba/libsysgba]: https://github.com/AntonioND/libugba

--- a/subprojects/libsavgba.wrap
+++ b/subprojects/libsavgba.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/aronson/libsavgba
+revision = v3.3.2
+
+[provide]
+dependency_names = libsavgba


### PR DESCRIPTION
The library [libsavgba](https://laqieer.github.io/libsavgba/) has been useful to me in my GBA development and I think it would be a great addition to meson-gba.

I've forked the project to patch in C++ support to its headers and add a meson.build we use in Apotris as a subproject. It's been vetted well on multiple machines by several users. Open to changes if you want to review it [here](https://github.com/aronson/libsavgba/blob/main/meson.build).

Tested within meson-gba by adding it to the deps and building the example project.