### PR TITLE
feat: support agbpack multiboot image compressor tool from asiekierka

### DIFF
--- a/subprojects/agbpack.wrap
+++ b/subprojects/agbpack.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/WonderfulToolchain/agbpack.git
+revision = main
+clone-recursive = true
+diff_files = agbpack/native_tool.patch
+
+[provide]
+program_names = agbpack

--- a/subprojects/packagefiles/agbpack/native_tool.patch
+++ b/subprojects/packagefiles/agbpack/native_tool.patch
@@ -1,0 +1,21 @@
+diff --git a/meson.build b/meson.build
+index db8c5e5..706c9d4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,6 +1,6 @@
+ project('agbpack', 'c', default_options: 'c_std=gnu11')
+ 
+-executable('agbpack', [
++agbpack = executable('agbpack', [
+     'rt/out/crt0_multiboot_bin.c',
+     'rt/out/crt0_rom_bin.c',
+     'src/main.c',
+@@ -12,4 +12,7 @@ executable('agbpack', [
+     'vendor/apultra/src/libdivsufsort/lib/divsufsort_utils.c',
+     'vendor/apultra/src/libdivsufsort/lib/sssort.c',
+     'vendor/apultra/src/libdivsufsort/lib/trsort.c'
+-], include_directories: include_directories('rt/out', 'src', 'vendor/apultra/src', 'vendor/apultra/src/libdivsufsort/include'))
++], include_directories: include_directories('rt/out', 'src', 'vendor/apultra/src', 'vendor/apultra/src/libdivsufsort/include'),
++native: true)
++
++meson.override_find_program('agbpack', agbpack)


### PR DESCRIPTION
[From upstream](https://github.com/WonderfulToolchain/agbpack) this tool compresses multiboot images and decompresses them on the GBA live to reduce time uploading, prevent a copy from EWRAM to IWRAM, etc.

Used like so:
```py
    name = "my-cool-project"
    subproject('agbpack')
    agbpack = find_program('agbpack', required: true)

    # Base multiboot elf binary
    multi = executable(
        name + '-multi',
        sources,
        cpp_args: ['-DMULTIBOOT'],
        c_args: ['-DMULTIBOOT'],
        include_directories: includes,
        dependencies: dependencies_multi,
        name_suffix: 'elf',
    )

    # Base multiboot ROM
    multi_base = custom_target(
        name + '-multi-base',
        input: multi,
        output: name + '-multi-base.gba',
        command: [agbpack, '@INPUT@', '@OUTPUT@'],
    )
```

Additional changes to minrt are required to use this optimally which I considered outside of the scope of this PR. I will PR to minrt when my changes are stable on all compilers.